### PR TITLE
Fixing issue around redis server authentication using redis client. P…

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,7 +11,7 @@ function Connection(options) {
   var port = options.port || 6379;
   var host = options.host || '127.0.0.1';
   this.conn = redis.createClient(port, host, {
-    auth: options.auth
+    auth_pass: options.auth
   });
 
   this.conn.on('ready', function () {


### PR DESCRIPTION
…arameter name passes as option to redis client was wrong, changing it from from 'auth' to 'auth_pass'