### PR TITLE
Remove deprecated listeners

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -30,12 +30,8 @@ function Connection(options) {
     self.emit('end');
   });
 
-  this.conn.on('drain', function () {
+  this.conn.stream.on('drain', function () {
     self.emit('drain');
-  });
-
-  this.conn.on('idle', function () {
-    self.emit('idle');
   });
   
   events.EventEmitter.call(this);

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,9 @@ RedisComplete.prototype.remove = function (options, cb) {
   var ids = (options.id instanceof Array) ? options.id : [options.id];
 
   async.each(ids, function (id, cb) {
+    if (id === undefined || id === null) {
+      return cb();
+    }
     self.conn.hdel({key: self.app + ':' + ns + ':docs', field: id}, function (err) {
       err && cb(err);
       if (!err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,10 +40,6 @@ function RedisComplete(options) {
     self.emit('drain');
   });
 
-  this.conn.on('idle', function () {
-    self.emit('idle');
-  });
-
   events.EventEmitter.call(this);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rediscomplete",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "A fully CRUD redis autocomplete engine inspired from the antirez and patshaughnessy blogs.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rediscomplete",
+  "name": "@resourcefulhumans/rediscomplete",
   "version": "1.9.0",
   "description": "A fully CRUD redis autocomplete engine inspired from the antirez and patshaughnessy blogs.",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/petreboy14/rediscomplete.git"
+    "url": "git+https://github.com/ResourcefulHumans/rediscomplete.git"
   },
   "keywords": [
     "redis",
@@ -19,10 +19,7 @@
   ],
   "author": "Peter Henning",
   "license": "BSD-2-Clause",
-  "bugs": {
-    "url": "https://github.com/petreboy14/rediscomplete/issues"
-  },
-  "homepage": "https://github.com/petreboy14/rediscomplete",
+  "homepage": "https://github.com/ResourcefulHumans/rediscomplete",
   "dependencies": {
     "async": "0.9.0",
     "hiredis": "^0.4.1",
@@ -33,5 +30,9 @@
     "lab": "^5.2.1",
     "precommit-hook": "~0.3.9",
     "should": "~2.1.1"
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rediscomplete",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A fully CRUD redis autocomplete engine inspired from the antirez and patshaughnessy blogs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix for listeners that are deprecated and removed.
`drain` event: https://github.com/NodeRedis/node_redis#stream
`idle` removed: https://github.com/NodeRedis/node_redis/blob/master/changelog.md#v250-1---07-mar-2016